### PR TITLE
Update glossary in developer guide

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -359,7 +359,7 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 1. User requests to view list
 2. ClickConnect shows a list of persons
 3. User requests to delete a specific person in the list
-4. ClickConnect deletes the person 
+4. ClickConnect deletes the person
 5. Use case ends.
 
 **Extensions**
@@ -397,12 +397,12 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 **MSS**
 
 1. User requests to add a new contact
-2. ClickConnect displays a success message after the new contact is successfully added 
+2. ClickConnect displays a success message after the new contact is successfully added
 3. Use case ends
 
 **Extensions**
 
-* 1a. User enters an invalid command 
+* 1a. User enters an invalid command
     * 1a1. ClickConnect alerts the user that the command is invalid and displays the correct format
     * Use case resumes
 * 1b. User tries to add a contact that already exists in ClickConnect
@@ -445,23 +445,23 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 * **API(Application Programming Interface)**: Defines how software components interact with each other
 * **Above average typing speed**: Typing speed of more than 40 words per minute
-* **Architecture**: The high-level design and structure of the application
-* **Archive**: Moving a contact to a secondary space in the address book of less importance
+* **Architecture**: The high-level design and code structure of FitBook
+* **Archive**: Moving a contact to a secondary space in FitBook that is of less importance
 * **CLI (Command Line Interface)**: A user interface that is based on interaction with the terminal or console
-* **ClickConnect**: An address book with client management capabilities
-* **Client**: A customer of the target user (ie. people engaging the services of a Freelance Photographer)
-* **Contact**: A person whose details are stored in the address book
-* **GUI (Graphical User Interface)**: The visual interface of the address book that users interact with
+* **FitBook**: An address book with additional capabilities for managing personal training clients
+* **Client**: A personal training customer of the target user (ie. people engaging the services of a Personal Trainer)
+* **Contact**: A person whose details are stored in FitBook
+* **GUI (Graphical User Interface)**: The visual interface of FitBook that users interact with
 * **JSON (JavaScript Object Notation)**:  A lightweight data-interchange format used for storing and transporting data
-* **JavaFX**: A set of graphics and media packages that enables developers to design, create, test and debug client applications
+* **JavaFX**: A set of graphics and media packages that enables developers to design, create, test and debug applications
 * **Low-end devices**: Computers with lesser than average hardware resources such as processing power and memory
 * **Mainstream OS**: Windows, Linux, Unix, MacOS
 * **PlantUML**: A tool for creating UML diagrams from plain text
 * **Private contact detail**: A contact detail that is not meant to be shared with others
-* **Responsive performance**: No noticeable delay of the address book during execution
+* **Responsive performance**: No noticeable delay of FitBook during user interaction
 * **Sequence Diagram**: A UML diagram that depicts how objects interact with each other in a sequence
 * **UI (User Interface)**: Manages user interactions with graphic interface elements
-* **Usage instructions**: Documentation detailing the address book's features and how to navigate about them
+* **Usage instructions**: Documentation detailing FitBook's features and how to navigate about them
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -445,33 +445,23 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 * **API(Application Programming Interface)**: Defines how software components interact with each other
 * **Above average typing speed**: Typing speed of more than 40 words per minute
-* **Architecture**: The high-level design and structure of the application consisting of components such as UI, Model and Storage
+* **Architecture**: The high-level design and structure of the application
 * **Archive**: Moving a contact to a secondary space in the address book of less importance
 * **CLI (Command Line Interface)**: A user interface that is based on interaction with the terminal or console
-* **ClickConnect**: A client management tool used to store contact details, such as names and phone numbers
+* **ClickConnect**: An address book with client management capabilities
 * **Client**: A customer of the target user (ie. people engaging the services of a Freelance Photographer)
-* **Command**: An object representing a user commend, created by parsing user input
-* **Commons**: A collection of shared resources or classes used by multiple parts of the application
-* **Contact**: A person of whose details are stored in the address book
-* **GUI (Graphical User Interface)**: The visual interface of the ClickConnect that users interact with
+* **Contact**: A person whose details are stored in the address book
+* **GUI (Graphical User Interface)**: The visual interface of the address book that users interact with
 * **JSON (JavaScript Object Notation)**:  A lightweight data-interchange format used for storing and transporting data
 * **JavaFX**: A set of graphics and media packages that enables developers to design, create, test and debug client applications
-* **Logic**: Refers to the component responsible for interpreting and executing user inputs
-* **Low-end devices**: Computers or devices with limited processing power, memory, and hardware
+* **Low-end devices**: Computers with lesser than average hardware resources such as processing power and memory
 * **Mainstream OS**: Windows, Linux, Unix, MacOS
-* **Model**: In the context of ClickConnect, it refers to the component that holds and manages application data
-* **ObservableList**: A unmodifiable list that automatically notifies to UI to update whenever the data changes
-* **Parser**: A class responsible for parsing user input into command objects
 * **PlantUML**: A tool for creating UML diagrams from plain text
 * **Private contact detail**: A contact detail that is not meant to be shared with others
 * **Responsive performance**: No noticeable delay of the address book during execution
 * **Sequence Diagram**: A UML diagram that depicts how objects interact with each other in a sequence
-* **Storage**: A class responsible for reading and writing data to and from the hard disk
 * **UI (User Interface)**: Manages user interactions with graphic interface elements
-* **UniquePersonList**: List that stores non-duplicate person objects 
-* **Usage instructions**: Documentation detailing the address book's features and how to navigate them
-* **UserPref**: Stores the user's preferences 
-* **VersionedAddressBook**: An extension of extends ClickConnect that adds undo/redo functionality
+* **Usage instructions**: Documentation detailing the address book's features and how to navigate about them
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -453,28 +453,32 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 
 ### Glossary
 
-* **API(Application Programming Interface)**: Defines how software components interact with each other
 * **Above average typing speed**: Typing speed of more than 40 words per minute
 * **Architecture**: The high-level design and code structure of FitBook
 * **Archive**: Moving a contact to a secondary space in FitBook that is of less importance
-* **CLI (Command Line Interface)**: A user interface that is based on interaction with the terminal or console
-* **FitBook**: An address book with additional capabilities for managing personal training clients
+* **API(Application Programming Interface)**: Defines how software components interact with each other
 * **Client**: A personal training customer of the target user (ie. people engaging the services of a Personal Trainer)
 * **Contact**: A person whose details are stored in FitBook
+* **CLI (Command Line Interface)**: A user interface that is based on interaction with the terminal or console
+* **Fit**: In good health, especially because of regular exercise
+* **Fitness**: The condition of being physically fit and healthy
+* **FitBook**: An address book with additional capabilities for managing personal training clients
 * **GUI (Graphical User Interface)**: The visual interface of FitBook that users interact with
-* **JSON (JavaScript Object Notation)**:  A lightweight data-interchange format used for storing and transporting data
+* **Healthy**: In a good physical or mental condition
 * **JavaFX**: A set of graphics and media packages that enables developers to design, create, test and debug applications
+* **JSON (JavaScript Object Notation)**:  A lightweight data-interchange format used for storing and transporting data
 * **Low-end devices**: Computers with lesser than average hardware resources such as processing power and memory
 * **Mainstream OS**: Windows, Linux, Unix, MacOS
 * **Model**: In the context of FitBook, it refers to the component that holds and manages application data
-* **ObservableList**: A unmodifiable list that automatically notifies to UI to update whenever the data changes
-* **Parser**: A class responsible for parsing user input into command objects
+* **Personal Health Information**: Details such as weight, body mass index, allergies, medical history etc.
+* **Personal Trainer (PT)**: A person who helps others plan and implement a fitness regime
 * **PlantUML**: A tool for creating UML diagrams from plain text
 * **Private contact detail**: A contact detail that is not meant to be shared with others
 * **Responsive performance**: No noticeable delay of FitBook during user interaction
 * **Sequence Diagram**: A UML diagram that depicts how objects interact with each other in a sequence
-* **UI (User Interface)**: Manages user interactions with graphic interface elements
 * **Usage instructions**: Documentation detailing FitBook's features and how to navigate about them
+* **User**: The person using FitBook
+* **UI (User Interface)**: Manages user interactions with graphic interface elements
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -469,7 +469,6 @@ Priorities: High (must have) - `* * *`, Medium (nice to have) - `* *`, Low (unli
 * **JSON (JavaScript Object Notation)**:  A lightweight data-interchange format used for storing and transporting data
 * **Low-end devices**: Computers with lesser than average hardware resources such as processing power and memory
 * **Mainstream OS**: Windows, Linux, Unix, MacOS
-* **Model**: In the context of FitBook, it refers to the component that holds and manages application data
 * **Personal Health Information**: Details such as weight, body mass index, allergies, medical history etc.
 * **Personal Trainer (PT)**: A person who helps others plan and implement a fitness regime
 * **PlantUML**: A tool for creating UML diagrams from plain text


### PR DESCRIPTION
Remove glossary for classes (explanation already in JavaDocs), minor tweaks.
Rename ClickConnect to FitBook as per #40 