### PR TITLE
BugFix: Help window formatting

### DIFF
--- a/src/main/java/seedu/address/commons/util/AppUtil.java
+++ b/src/main/java/seedu/address/commons/util/AppUtil.java
@@ -9,6 +9,41 @@ import seedu.address.MainApp;
  * A container for App specific utility functions
  */
 public class AppUtil {
+    /**
+     * Determines the operating system
+     */
+    public static enum OS {
+        WIN,
+        MAC,
+        LINUX;
+
+        /**
+         * Determines if the operating system is Windows
+         *
+         * @return True if operating system is Windows, False otherwise
+         */
+        public static boolean isWindows() {
+            return System.getProperty("os.name").trim().toLowerCase().contains(WIN.toString().toLowerCase());
+        }
+
+        /**
+         * Determines if the operating system is MacOS
+         *
+         * @return True if operating system is MacOS, False otherwise
+         */
+        public static boolean isMac() {
+            return System.getProperty("os.name").trim().toLowerCase().contains(MAC.toString().toLowerCase());
+        }
+
+        /**
+         * Determines if the operating system is Linux
+         *
+         * @return True if operating system is Linux, False otherwise
+         */
+        public static boolean isLinux() {
+            return System.getProperty("os.name").trim().toLowerCase().contains(LINUX.toString().toLowerCase());
+        }
+    }
 
     /**
      * Gets an {@code Image} from the specified path.
@@ -19,7 +54,8 @@ public class AppUtil {
     }
 
     /**
-     * Checks that {@code condition} is true. Used for validating arguments to methods.
+     * Checks that {@code condition} is true. Used for validating arguments to
+     * methods.
      *
      * @throws IllegalArgumentException if {@code condition} is false.
      */
@@ -30,9 +66,11 @@ public class AppUtil {
     }
 
     /**
-     * Checks that {@code condition} is true. Used for validating arguments to methods.
+     * Checks that {@code condition} is true. Used for validating arguments to
+     * methods.
      *
-     * @throws IllegalArgumentException with {@code errorMessage} if {@code condition} is false.
+     * @throws IllegalArgumentException with {@code errorMessage} if
+     *                                  {@code condition} is false.
      */
     public static void checkArgument(Boolean condition, String errorMessage) {
         if (!condition) {

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -127,7 +127,7 @@ public class HelpWindow extends UiPart<Stage> {
     @FXML
     private void openUrl() {
         try {
-            if (System.getProperty("os.name").trim().toLowerCase().contains(OS.LINUX.toString().toLowerCase())) {
+            if (AppUtil.OS.isLinux()) {
                 final Clipboard clipboard = Clipboard.getSystemClipboard();
                 final ClipboardContent url = new ClipboardContent();
                 url.putString(USERGUIDE_URL);

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -23,11 +23,14 @@ public class HelpWindow extends UiPart<Stage> {
     public static final String USERGUIDE_URL = "https://ay2324s2-cs2103t-t17-3.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Available commands:\n"
             + "help \t- Shows this window.\n"
-            + String.format("add %s\t- Adds a client to FitBook.\n", (AppUtil.OS.isLinux() || AppUtil.OS.isWindows()) ? "\t" : "")
+            + String.format("add %s\t- Adds a client to FitBook.\n",
+                    AppUtil.OS.isLinux() || AppUtil.OS.isWindows() ? "\t" : "")
             + "list \t\t- Shows a list of all clients saved in FitBook.\n"
-            + String.format("edit %s\t- Edits an existing client in FitBook.\n", (AppUtil.OS.isLinux() || AppUtil.OS.isWindows()) ? "\t" : "")
+            + String.format("edit %s\t- Edits an existing client in FitBook.\n",
+                    AppUtil.OS.isLinux() || AppUtil.OS.isWindows() ? "\t" : "")
             + "note \t- Adds a new note to a client.\n"
-            + String.format("find %s\t- Finds all clients whose specified attribute contains the specified keyword.\n", (AppUtil.OS.isWindows()) ? "\t" : "")
+            + String.format("find %s\t- Finds all clients whose specified attribute contains the specified keyword.\n",
+                    AppUtil.OS.isWindows() ? "\t" : "")
             + "delete \t- Deletes the specified client from FitBook.\n"
             + "clear \t- Clears all entries from FitBook. USE WITH CAUTION.\n"
             + String.format("exit %s\t- Exits FitBook.\n", (AppUtil.OS.isLinux() || AppUtil.OS.isWindows()) ? "\t" : "")
@@ -59,7 +62,7 @@ public class HelpWindow extends UiPart<Stage> {
         }
 
         helpMessage.setText(HELP_MESSAGE);
-        
+
     }
 
     /**

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -9,14 +9,16 @@ import java.util.logging.Logger;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
+import javafx.scene.input.Clipboard;
+import javafx.scene.input.ClipboardContent;
 import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.util.AppUtil.OS;
 
 /**
  * Controller for a help page
  */
 public class HelpWindow extends UiPart<Stage> {
-
     public static final String USERGUIDE_URL = "https://ay2324s2-cs2103t-t17-3.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Available commands:\n"
             + "help \t- Shows this window.\n"
@@ -28,6 +30,22 @@ public class HelpWindow extends UiPart<Stage> {
             + "delete \t- Deletes the specified client from FitBook.\n"
             + "clear \t- Clears all entries from FitBook. USE WITH CAUTION.\n"
             + "exit \t- Exits FitBook.\n"
+            + "\n"
+            + "To view more information about a specific command, enter the command into the input box and press "
+            + "<Enter>.\n"
+            + "\n"
+            + "Need more help? Refer to the user guide at " + USERGUIDE_URL;
+
+    public static final String HELP_MESSAGE_ALTERNATE = "Available commands:\n"
+            + "help \t- Shows this window.\n"
+            + "add \t\t- Adds a client to FitBook.\n"
+            + "list \t\t- Shows a list of all clients saved in FitBook.\n"
+            + "edit \t\t- Edits an existing client in FitBook.\n"
+            + "note \t- Adds a new note to a client.\n"
+            + "find \t- Finds all clients whose specified attribute contains the specified keyword.\n"
+            + "delete \t- Deletes the specified client from FitBook.\n"
+            + "clear \t- Clears all entries from FitBook. USE WITH CAUTION.\n"
+            + "exit \t\t- Exits FitBook.\n"
             + "\n"
             + "To view more information about a specific command, enter the command into the input box and press "
             + "<Enter>.\n"
@@ -50,7 +68,16 @@ public class HelpWindow extends UiPart<Stage> {
      */
     public HelpWindow(Stage root) {
         super(FXML, root);
-        helpMessage.setText(HELP_MESSAGE);
+
+        if (OS.isLinux()) {
+            copyButton.setText("Copy URL");
+        }
+
+        if (OS.isLinux() || OS.isWindows()) {
+            helpMessage.setText(HELP_MESSAGE_ALTERNATE);
+        } else {
+            helpMessage.setText(HELP_MESSAGE);
+        }
     }
 
     /**
@@ -83,6 +110,7 @@ public class HelpWindow extends UiPart<Stage> {
      */
     public void show() {
         logger.fine("Showing help page about the application.");
+
         getRoot().show();
         getRoot().centerOnScreen();
     }
@@ -114,7 +142,14 @@ public class HelpWindow extends UiPart<Stage> {
     @FXML
     private void openUrl() {
         try {
-            Desktop.getDesktop().browse(new URI(USERGUIDE_URL));
+            if (System.getProperty("os.name").trim().toLowerCase().contains(OS.LINUX.toString().toLowerCase())) {
+                final Clipboard clipboard = Clipboard.getSystemClipboard();
+                final ClipboardContent url = new ClipboardContent();
+                url.putString(USERGUIDE_URL);
+                clipboard.setContent(url);
+            } else {
+                Desktop.getDesktop().browse(new URI(USERGUIDE_URL));
+            }
         } catch (URISyntaxException | IOException e) {
             logger.warning("Something went wrong when opening user guide URL.");
         }

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -13,6 +13,7 @@ import javafx.scene.input.Clipboard;
 import javafx.scene.input.ClipboardContent;
 import javafx.stage.Stage;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.util.AppUtil;
 import seedu.address.commons.util.AppUtil.OS;
 
 /**
@@ -22,30 +23,14 @@ public class HelpWindow extends UiPart<Stage> {
     public static final String USERGUIDE_URL = "https://ay2324s2-cs2103t-t17-3.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Available commands:\n"
             + "help \t- Shows this window.\n"
-            + "add \t- Adds a client to FitBook.\n"
+            + String.format("add %s\t- Adds a client to FitBook.\n", (AppUtil.OS.isLinux() || AppUtil.OS.isWindows()) ? "\t" : "")
             + "list \t\t- Shows a list of all clients saved in FitBook.\n"
-            + "edit \t- Edits an existing client in FitBook.\n"
+            + String.format("edit %s\t- Edits an existing client in FitBook.\n", (AppUtil.OS.isLinux() || AppUtil.OS.isWindows()) ? "\t" : "")
             + "note \t- Adds a new note to a client.\n"
-            + "find \t- Finds all clients whose specified attribute contains the specified keyword.\n"
+            + String.format("find %s\t- Finds all clients whose specified attribute contains the specified keyword.\n", (AppUtil.OS.isWindows()) ? "\t" : "")
             + "delete \t- Deletes the specified client from FitBook.\n"
             + "clear \t- Clears all entries from FitBook. USE WITH CAUTION.\n"
-            + "exit \t- Exits FitBook.\n"
-            + "\n"
-            + "To view more information about a specific command, enter the command into the input box and press "
-            + "<Enter>.\n"
-            + "\n"
-            + "Need more help? Refer to the user guide at " + USERGUIDE_URL;
-
-    public static final String HELP_MESSAGE_ALTERNATE = "Available commands:\n"
-            + "help \t- Shows this window.\n"
-            + "add \t\t- Adds a client to FitBook.\n"
-            + "list \t\t- Shows a list of all clients saved in FitBook.\n"
-            + "edit \t\t- Edits an existing client in FitBook.\n"
-            + "note \t- Adds a new note to a client.\n"
-            + "find \t- Finds all clients whose specified attribute contains the specified keyword.\n"
-            + "delete \t- Deletes the specified client from FitBook.\n"
-            + "clear \t- Clears all entries from FitBook. USE WITH CAUTION.\n"
-            + "exit \t\t- Exits FitBook.\n"
+            + String.format("exit %s\t- Exits FitBook.\n", (AppUtil.OS.isLinux() || AppUtil.OS.isWindows()) ? "\t" : "")
             + "\n"
             + "To view more information about a specific command, enter the command into the input box and press "
             + "<Enter>.\n"
@@ -73,11 +58,8 @@ public class HelpWindow extends UiPart<Stage> {
             copyButton.setText("Copy URL");
         }
 
-        if (OS.isLinux() || OS.isWindows()) {
-            helpMessage.setText(HELP_MESSAGE_ALTERNATE);
-        } else {
-            helpMessage.setText(HELP_MESSAGE);
-        }
+        helpMessage.setText(HELP_MESSAGE);
+        
     }
 
     /**

--- a/src/test/java/seedu/address/commons/util/AppUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/AppUtilTest.java
@@ -1,9 +1,12 @@
 package seedu.address.commons.util;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 public class AppUtilTest {
 
@@ -32,5 +35,23 @@ public class AppUtilTest {
     public void checkArgument_falseWithErrorMessage_throwsIllegalArgumentException() {
         String errorMessage = "error message";
         assertThrows(IllegalArgumentException.class, errorMessage, () -> AppUtil.checkArgument(false, errorMessage));
+    }
+
+    @Test
+    @EnabledOnOs({ OS.WINDOWS })
+    public void isWindows() {
+        assertTrue(AppUtil.OS.isWindows());
+    }
+
+    @Test
+    @EnabledOnOs({ OS.MAC })
+    public void isMac() {
+        assertTrue(AppUtil.OS.isMac());
+    }
+
+    @Test
+    @EnabledOnOs({ OS.LINUX })
+    public void isLinux() {
+        assertTrue(AppUtil.OS.isLinux());
     }
 }


### PR DESCRIPTION
## Description
Help window currently shows different formats for different OS. This PR sets the formatting based on the system OS for a centralized look.
> `Open User Guide` button is reverted to `Copy URL` button for Linux machines as the implementation it is unsupported

Resolves #80.

## Previews
### Linux
![image](https://github.com/AY2324S2-CS2103T-T17-3/tp/assets/44436551/eb88d78f-73f2-4d6e-b094-5ee988ee0eb5)

### MacOS
![image](https://github.com/AY2324S2-CS2103T-T17-3/tp/assets/44436551/3b9b4a0a-404b-4ef9-994d-345d2dd6a6d7)

### Windows
![image](https://github.com/AY2324S2-CS2103T-T17-3/tp/assets/44436551/e54069e5-e37c-4ecf-85cc-2ac145a9c421)