### PR TITLE
Bugfix: Edge case causing QR not to generate

### DIFF
--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -106,8 +106,8 @@ public class ModelManager implements Model {
 
     @Override
     public void addPerson(Person person) {
-        addressBook.addPerson(person);
         person.generateQrCode();
+        addressBook.addPerson(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 


### PR DESCRIPTION
Resolves #124 

Previously, generation of qr code was called after `UniquePersonList` was being updated (from the main thread). This likely caused a situation similiar to a race condition as the UI thread and main thread competes to see which executes first, the winner will determine whether the qrcode is displayed or not.