### PR TITLE
Task: Add backwards compatibility for new note field

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -30,7 +30,6 @@ class JsonAdaptedPerson {
     private final String email;
     private final String address;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
-    @JsonProperty(defaultValue = "")
     private final String note;
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -30,6 +30,7 @@ class JsonAdaptedPerson {
     private final String email;
     private final String address;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
+    @JsonProperty(defaultValue = "")
     private final String note;
 
     /**
@@ -46,11 +47,7 @@ class JsonAdaptedPerson {
         if (tags != null) {
             this.tags.addAll(tags);
         }
-        // Add backwards compatibility for versions prior to v1.2
-        if (note == null) {
-            note = "";
-        }
-        this.note = note;
+        this.note = note != null ? note : "";
     }
 
     /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -46,6 +46,10 @@ class JsonAdaptedPerson {
         if (tags != null) {
             this.tags.addAll(tags);
         }
+        // Add backwards compatibility for versions prior to v1.2
+        if (note == null) {
+            note = "";
+        }
         this.note = note;
     }
 


### PR DESCRIPTION
Resolves #121 

Instead of having a separate migration script requiring the user to run it separately, this implementation resolves the issue quietly by adding a `Note` with an empty value if it is not present in `addressbook.json`.