### PR TITLE
Rename site header shown when printing

### DIFF
--- a/docs/_sass/minima/_base.scss
+++ b/docs/_sass/minima/_base.scss
@@ -288,7 +288,7 @@ table {
     text-align: center;
   }
   .site-header:before {
-    content: "AB-3";
+    content: "FitBook";
     font-size: 32px;
   }
 }


### PR DESCRIPTION
<img width="591" alt="image" src="https://github.com/AY2324S2-CS2103T-T17-3/tp/assets/40649376/537849b5-f3a1-470c-8a5d-ee60c8e85643">

This PR should change the 'AB-3' to 'FitBook'