### PR TITLE
Remove deprecated FXML fields in PersonCard

### DIFF
--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -4,9 +4,7 @@ import java.util.Comparator;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
-import javafx.scene.image.ImageView;
 import javafx.scene.layout.FlowPane;
-import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
 import seedu.address.model.person.Person;
 import seedu.address.model.tag.Tag;
@@ -31,23 +29,13 @@ public class PersonCard extends UiPart<Region> {
     public final Person person;
 
     @FXML
-    private HBox cardPane;
-    @FXML
     private Label name;
     @FXML
     private Label id;
     @FXML
     private Label phone;
     @FXML
-    private Label address;
-    @FXML
-    private Label email;
-    @FXML
     private FlowPane tags;
-    @FXML
-    private ImageView qrcode;
-    @FXML
-    private Label note;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to


### PR DESCRIPTION
Since we have moved to a new ui design, we can remove some deprecated fields in `PersonCard.java`.