### PR TITLE
Remove doublespace

### DIFF
--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -19,7 +19,7 @@
       <padding>
         <Insets bottom="5.0" left="15.0" right="5.0" top="5.0" />
       </padding>
-      <HBox alignment="CENTER_LEFT" spacing="5">
+      <HBox alignment="CENTER_LEFT" spacing="0.5">
         <Label fx:id="id" styleClass="cell_big_label">
           <minWidth>
             <!-- Ensures that the label text is never truncated -->


### PR DESCRIPTION
Removed double-space on person list card

`Before:`
![image](https://github.com/AY2324S2-CS2103T-T17-3/tp/assets/73015364/783c7297-b613-4e35-baff-fe93faada9d5)

<hr>


`After:`
![Screenshot 2024-03-28 at 10 46 05 AM](https://github.com/AY2324S2-CS2103T-T17-3/tp/assets/73015364/20ada54d-8a9d-449c-8f8b-a464e2245675)
