### PR TITLE
Bugfix: Input validation for phone numbers is too strict

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -29,6 +29,8 @@ public class Messages {
     public static final String MESSAGE_ONE_CLIENT_LISTED = "1 client listed!";
     public static final String MESSAGE_ALL_CLIENTS_LISTED = "%1$d clients listed!";
 
+    public static final String MESSAGE_WARN = "\n\nWARNING: %s";
+
     /**
      * Returns an error message indicating the duplicate prefixes.
      */

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -55,7 +55,7 @@ public class AddCommand extends Command {
      *
      * @return The warning message, or an empty string if none.
      */
-    public String getMessageWarn() {
+    private String getMessageWarn() {
         boolean isPhoneOfExpectedFormat = toAdd.getPhone().isExpectedFormat();
 
         if (!isPhoneOfExpectedFormat) {

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -12,6 +12,7 @@ import seedu.address.commons.util.ToStringBuilder;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
 
 /**
  * Adds a person to the address book.
@@ -36,6 +37,8 @@ public class AddCommand extends Command {
             + PREFIX_TAG + "friend ";
 
     public static final String MESSAGE_SUCCESS = "Client successfully added!\n--------------------------\n%1$s";
+    public static final String MESSAGE_WARN = "\n\nWARNING: %s";
+
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";
     private final Person toAdd;
 
@@ -47,6 +50,21 @@ public class AddCommand extends Command {
         toAdd = person;
     }
 
+    /**
+     * Gets the warning message for the command's execution.
+     *
+     * @return The warning message, or an empty string if none.
+     */
+    public String getMessageWarn() {
+        boolean isPhoneOfExpectedFormat = toAdd.getPhone().isExpectedFormat();
+
+        if (!isPhoneOfExpectedFormat) {
+            return String.format(MESSAGE_WARN, Phone.MESSAGE_EXPECTED);
+        }
+
+        return "";
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
@@ -56,7 +74,13 @@ public class AddCommand extends Command {
         }
 
         model.addPerson(toAdd);
-        return new CommandResult(String.format(MESSAGE_SUCCESS, toAdd.getFormattedMessage()));
+
+        String messageSuccess = String.format(MESSAGE_SUCCESS, toAdd.getFormattedMessage());
+        String messageWarn = this.getMessageWarn();
+
+        String messageResult = String.format("%s%s", messageSuccess, messageWarn);
+
+        return new CommandResult(messageResult);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -9,6 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.commons.util.ToStringBuilder;
+import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Person;
@@ -59,7 +60,7 @@ public class AddCommand extends Command {
         boolean isPhoneOfExpectedFormat = toAdd.getPhone().isExpectedFormat();
 
         if (!isPhoneOfExpectedFormat) {
-            return String.format(MESSAGE_WARN, Phone.MESSAGE_EXPECTED);
+            return String.format(Messages.MESSAGE_WARN, Phone.MESSAGE_EXPECTED);
         }
 
         return "";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -52,7 +52,6 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS =
             "Successfully edited client!\n--------------------------\n%1$s";
-    public static final String MESSAGE_WARN = "\n\nWARNING: %s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.\n%1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
@@ -96,7 +95,7 @@ public class EditCommand extends Command {
         boolean isPhoneOfExpectedFormat = editedPerson.getPhone().isExpectedFormat();
 
         if (!isPhoneOfExpectedFormat) {
-            return String.format(MESSAGE_WARN, Phone.MESSAGE_EXPECTED);
+            return String.format(Messages.MESSAGE_WARN, Phone.MESSAGE_EXPECTED);
         }
 
         return "";

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -92,7 +92,7 @@ public class EditCommand extends Command {
      *
      * @return The warning message, or an empty string if none.
      */
-    public String getMessageWarn(Person editedPerson) {
+    private String getMessageWarn(Person editedPerson) {
         boolean isPhoneOfExpectedFormat = editedPerson.getPhone().isExpectedFormat();
 
         if (!isPhoneOfExpectedFormat) {

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -52,6 +52,7 @@ public class EditCommand extends Command {
 
     public static final String MESSAGE_EDIT_PERSON_SUCCESS =
             "Successfully edited client!\n--------------------------\n%1$s";
+    public static final String MESSAGE_WARN = "\n\nWARNING: %s";
     public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.\n%1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book.";
 
@@ -86,6 +87,21 @@ public class EditCommand extends Command {
         return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedNote, updatedTags);
     }
 
+    /**
+     * Gets the warning message for the command's execution.
+     *
+     * @return The warning message, or an empty string if none.
+     */
+    public String getMessageWarn(Person editedPerson) {
+        boolean isPhoneOfExpectedFormat = editedPerson.getPhone().isExpectedFormat();
+
+        if (!isPhoneOfExpectedFormat) {
+            return String.format(MESSAGE_WARN, Phone.MESSAGE_EXPECTED);
+        }
+
+        return "";
+    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
@@ -106,7 +122,13 @@ public class EditCommand extends Command {
 
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson.getFormattedMessage()));
+
+        String messageSuccess = String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedPerson.getFormattedMessage());
+        String messageWarn = this.getMessageWarn(editedPerson);
+
+        String messageResult = String.format("%s%s", messageSuccess, messageWarn);
+
+        return new CommandResult(messageResult);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -12,7 +12,8 @@ public class Phone extends Attribute<String> {
     public static final String MESSAGE_CONSTRAINTS =
         "Phone numbers should only contain digits and have a minimum length of 1.";
     public static final String MESSAGE_EXPECTED =
-        "The phone number supplied does not appear to be from Singapore,\nfor other types of numbers, please ensure that you have keyed it in correctly.";
+        "The phone number supplied does not appear to be from Singapore,\nfor other types of numbers, "
+            + "please ensure that you have keyed it in correctly.";
     public static final String EXPECTED_FORMAT_REGEX = "^[689]\\d{7}$";
     public static final String REQUIRED_REGEX = "^\\d+$";
 

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -9,9 +9,11 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Phone extends Attribute<String> {
 
-    public static final String MESSAGE_CONSTRAINTS = "Phone numbers should only contain numbers,"
-            + "starts with either '6', '8' or '9' and be a total of 8 digits long";
-    public static final String VALIDATION_REGEX = "^[689]\\d{7}$";
+    public static final String MESSAGE_CONSTRAINTS = "Phone numbers should only contain digits and have a minimum length of 1.";
+    public static final String MESSAGE_EXPECTED =
+        "The phone number supplied does not appear to be from Singapore,\nfor other types of numbers, please ensure that you have keyed it in correctly.";
+    public static final String EXPECTED_FORMAT_REGEX = "^[689]\\d{7}$";
+    public static final String REQUIRED_REGEX = "^\\d+$";
 
     /**
      * Constructs a {@code Phone}.
@@ -28,7 +30,22 @@ public class Phone extends Attribute<String> {
      * Returns true if a given string is a valid phone number.
      */
     public static boolean isValidPhone(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return test.matches(REQUIRED_REGEX);
+    }
+
+    /**
+     * Determines if the phone value stored is of an expected format.
+     *
+     * @return true if the phone number is of an expected format, false otherwise.
+     */
+    public boolean isExpectedFormat() {
+        String phoneNumber = this.getValue();
+
+        if (!phoneNumber.isEmpty()) {
+            return phoneNumber.matches(EXPECTED_FORMAT_REGEX);
+        } else {
+            return false;
+        }
     }
 
     /**
@@ -36,7 +53,6 @@ public class Phone extends Attribute<String> {
      * Returns true if specified value is a substring of the phone value stored.
      *
      * @param otherValue Other value to check against
-     *
      * @return True if specified value is a match, False otherwise
      */
     @Override

--- a/src/main/java/seedu/address/model/person/Phone.java
+++ b/src/main/java/seedu/address/model/person/Phone.java
@@ -9,7 +9,8 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class Phone extends Attribute<String> {
 
-    public static final String MESSAGE_CONSTRAINTS = "Phone numbers should only contain digits and have a minimum length of 1.";
+    public static final String MESSAGE_CONSTRAINTS =
+        "Phone numbers should only contain digits and have a minimum length of 1.";
     public static final String MESSAGE_EXPECTED =
         "The phone number supplied does not appear to be from Singapore,\nfor other types of numbers, please ensure that you have keyed it in correctly.";
     public static final String EXPECTED_FORMAT_REGEX = "^[689]\\d{7}$";

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -27,19 +27,18 @@ public class PhoneTest {
         // invalid phone numbers
         assertFalse(Phone.isValidPhone("")); // empty string
         assertFalse(Phone.isValidPhone(" ")); // spaces only
-        assertFalse(Phone.isValidPhone("909828")); // less than 8 numbers
-        assertFalse(Phone.isValidPhone("909828910")); // more than 8 numbers
         assertFalse(Phone.isValidPhone("phone")); // non-numeric
         assertFalse(Phone.isValidPhone("9011p041")); // alphabets within digits
         assertFalse(Phone.isValidPhone("9312 1534")); // spaces within digits
-        assertFalse(Phone.isValidPhone("58909832")); // does not start with '6', '8' or '9'
-        assertFalse(Phone.isValidPhone("78909832")); // does not start with '6', '8' or '9'
+        assertFalse(Phone.isValidPhone("+193121534")); // with '+' symbol
+        assertFalse(Phone.isValidPhone("(193)121534")); // with '(' and ')' symbol
+        assertFalse(Phone.isValidPhone("193-121534")); // with '-' symbol
 
         // valid phone numbers
-        assertTrue(Phone.isValidPhone("93121534")); // exactly 8 numbers
-        assertTrue(Phone.isValidPhone("67392810")); // starts with '6'
-        assertTrue(Phone.isValidPhone("87392810")); // starts with '8'
-        assertTrue(Phone.isValidPhone("97392810")); // starts with '9'
+        assertTrue(Phone.isValidPhone("1")); // one digit
+        assertTrue(Phone.isValidPhone("12")); // one digit
+        assertTrue(Phone.isValidPhone("12345678901234567890")); // twenty digits
+        assertTrue(Phone.isValidPhone("123456789012345678901")); // twenty-one digits
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/PhoneTest.java
+++ b/src/test/java/seedu/address/model/person/PhoneTest.java
@@ -42,6 +42,30 @@ public class PhoneTest {
     }
 
     @Test
+    public void isExpectedFormat() {
+        Phone phone = new Phone("58909832"); // exactly 8 numbers but does not start with '6', '8' or '9'
+        assertFalse(phone.isExpectedFormat());
+
+        phone = new Phone("78909832"); // exactly 8 numbers but does not start with '6', '8' or '9'
+        assertFalse(phone.isExpectedFormat());
+
+        phone = new Phone("909828"); // less than 8 digits
+        assertFalse(phone.isExpectedFormat());
+
+        phone = new Phone("909828910"); // more than 8 digits
+        assertFalse(phone.isExpectedFormat());
+
+        phone = new Phone("67392810"); // exactly 8 numbers and start with '6'
+        assertTrue(phone.isExpectedFormat());
+
+        phone = new Phone("87392810"); // exactly 8 digits and start with '8'
+        assertTrue(phone.isExpectedFormat());
+
+        phone = new Phone("93121534"); // exactly 8 digits and start with '9'
+        assertTrue(phone.isExpectedFormat());
+    }
+
+    @Test
     public void equals() {
         Phone phone = new Phone("88888888");
 


### PR DESCRIPTION
The new constraint for phone numbers follows the regex `\d+`, requiring the user to input a phone number that contains only digits with a minimum length of 1.

The old constraint regex `[689]\d{7}$` has now been changed to an "expectation" instead. When users add a new client or edits an existing client, a warning message is displayed if it does not conform to Singapore numbers, but FitBook will still allow the addition/edition of such numbers.

Resolves #205 