### PR TITLE
Bug: Fix find command not searching newly added clients

### DIFF
--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -15,12 +15,14 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_WEIGHT;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.predicates.AddressContainsSubstringPredicate;
+import seedu.address.model.person.predicates.AlwaysTruePredicate;
 import seedu.address.model.person.predicates.CombinedPredicates;
 import seedu.address.model.person.predicates.EmailContainsSubstringPredicate;
 import seedu.address.model.person.predicates.HeightContainsRangePredicate;
 import seedu.address.model.person.predicates.NameContainsSubstringPredicate;
 import seedu.address.model.person.predicates.NoteContainsSubstringPredicate;
 import seedu.address.model.person.predicates.PhoneContainsSubstringPredicate;
+import seedu.address.model.person.predicates.SearchPredicate;
 import seedu.address.model.person.predicates.TagSetContainsAllTagsPredicate;
 import seedu.address.model.person.predicates.WeightMapContainsWeightRangePredicate;
 
@@ -52,8 +54,10 @@ public class FindCommandParser implements Parser<FindCommand> {
                 ParserUtil.parseSearchString(argMultimap.getValueOrEmpty(PREFIX_EMAIL)));
         AddressContainsSubstringPredicate addressPredicate = new AddressContainsSubstringPredicate(
                 ParserUtil.parseSearchString(argMultimap.getValueOrEmpty(PREFIX_ADDRESS)));
-        WeightMapContainsWeightRangePredicate weightPredicate = new WeightMapContainsWeightRangePredicate(
-                ParserUtil.parseSearchRange(argMultimap.getValue(PREFIX_WEIGHT)));
+        SearchPredicate<?> weightPredicate = argMultimap.getValue(PREFIX_WEIGHT).isPresent()
+                ? new WeightMapContainsWeightRangePredicate(
+                        ParserUtil.parseSearchRange(argMultimap.getValue(PREFIX_WEIGHT)))
+                : new AlwaysTruePredicate();
         HeightContainsRangePredicate heightPredicate = new HeightContainsRangePredicate(
                 ParserUtil.parseSearchRange(argMultimap.getValue(PREFIX_HEIGHT)));
         NoteContainsSubstringPredicate notePredicate = new NoteContainsSubstringPredicate(ParserUtil

--- a/src/main/java/seedu/address/model/person/predicates/AlwaysTruePredicate.java
+++ b/src/main/java/seedu/address/model/person/predicates/AlwaysTruePredicate.java
@@ -1,0 +1,18 @@
+package seedu.address.model.person.predicates;
+
+import seedu.address.model.person.Person;
+
+public class AlwaysTruePredicate extends SearchPredicate<String> {
+    /**
+     * Constructs a predicate to that is always true
+     *
+     */
+    public AlwaysTruePredicate() {
+        super("", null);
+    }
+
+    @Override
+    public boolean test(Person person) {
+        return true;
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -14,14 +14,17 @@ import static seedu.address.testutil.TypicalPersons.DANIEL;
 import static seedu.address.testutil.TypicalPersons.ELLE;
 import static seedu.address.testutil.TypicalPersons.FIONA;
 import static seedu.address.testutil.TypicalPersons.GEORGE;
+import static seedu.address.testutil.TypicalPersons.HOON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -41,6 +44,12 @@ import seedu.address.model.tag.Tag;
 public class FindCommandTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
     private Model expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    @BeforeEach
+    public void resetModels() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    }
 
     @Test
     public void equals() {
@@ -365,6 +374,24 @@ public class FindCommandTest {
         expectedModel.updateFilteredPersonList(combinedPredicates);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredPersonList());
+    }
+
+    @Test
+    public void execute_addPerson_PersonFound() throws CommandException {
+        String expectedMessage = String.format(MESSAGE_ONE_CLIENT_FOUND);
+
+        (new AddCommand(HOON)).execute(model);
+        (new AddCommand(HOON)).execute(expectedModel);
+
+        NameContainsSubstringPredicate namePredicate = new NameContainsSubstringPredicate("Hoon Meier");
+
+        CombinedPredicates combinedPredicates = new CombinedPredicates(namePredicate);
+
+        FindCommand command = new FindCommand(new CombinedPredicates(namePredicate));
+        expectedModel.updateFilteredPersonList(combinedPredicates);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(HOON),
+                model.getFilteredPersonList());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -31,6 +31,7 @@ import seedu.address.logic.messages.HelpCommandMessages;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.predicates.AddressContainsSubstringPredicate;
+import seedu.address.model.person.predicates.AlwaysTruePredicate;
 import seedu.address.model.person.predicates.CombinedPredicates;
 import seedu.address.model.person.predicates.EmailContainsSubstringPredicate;
 import seedu.address.model.person.predicates.HeightContainsRangePredicate;
@@ -38,7 +39,6 @@ import seedu.address.model.person.predicates.NameContainsSubstringPredicate;
 import seedu.address.model.person.predicates.NoteContainsSubstringPredicate;
 import seedu.address.model.person.predicates.PhoneContainsSubstringPredicate;
 import seedu.address.model.person.predicates.TagSetContainsAllTagsPredicate;
-import seedu.address.model.person.predicates.WeightMapContainsWeightRangePredicate;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.PersonUtil;
@@ -91,10 +91,9 @@ public class AddressBookParserTest {
         PhoneContainsSubstringPredicate phonePredicate = new PhoneContainsSubstringPredicate("");
         EmailContainsSubstringPredicate emailPredicate = new EmailContainsSubstringPredicate("");
         AddressContainsSubstringPredicate addressPredicate = new AddressContainsSubstringPredicate("");
-        WeightMapContainsWeightRangePredicate weightPredicate =
-                new WeightMapContainsWeightRangePredicate(new Pair<>(0f, Float.MAX_VALUE));
-        HeightContainsRangePredicate heightPredicate =
-                new HeightContainsRangePredicate(new Pair<>(0f, Float.MAX_VALUE));
+        AlwaysTruePredicate weightPredicate = new AlwaysTruePredicate();
+        HeightContainsRangePredicate heightPredicate = new HeightContainsRangePredicate(
+                new Pair<>(0f, Float.MAX_VALUE));
         NoteContainsSubstringPredicate notePredicate = new NoteContainsSubstringPredicate("");
         TagSetContainsAllTagsPredicate tagsPredicate = new TagSetContainsAllTagsPredicate(new HashSet<>());
         FindCommand expectedCommand = new FindCommand(new CombinedPredicates(
@@ -118,7 +117,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT,
-                        HelpCommandMessages.MESSAGE_USAGE), () -> parser.parseCommand(""));
+                HelpCommandMessages.MESSAGE_USAGE), () -> parser.parseCommand(""));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -21,6 +21,7 @@ import javafx.util.Pair;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.messages.FindCommandMessages;
 import seedu.address.model.person.predicates.AddressContainsSubstringPredicate;
+import seedu.address.model.person.predicates.AlwaysTruePredicate;
 import seedu.address.model.person.predicates.CombinedPredicates;
 import seedu.address.model.person.predicates.EmailContainsSubstringPredicate;
 import seedu.address.model.person.predicates.HeightContainsRangePredicate;
@@ -49,10 +50,10 @@ public class FindCommandParserTest {
             EMAIL);
     private static final AddressContainsSubstringPredicate ADDRESS_PREDICATE = new AddressContainsSubstringPredicate(
             ADDRESS);
-    private static final WeightMapContainsWeightRangePredicate WEIGHT_PREDICATE =
-            new WeightMapContainsWeightRangePredicate(new Pair<>(0f, 1000f));
-    private static final HeightContainsRangePredicate HEIGHT_PREDICATE =
-            new HeightContainsRangePredicate(new Pair<>(0f, 500f));
+    private static final WeightMapContainsWeightRangePredicate WEIGHT_PREDICATE = new WeightMapContainsWeightRangePredicate(
+            new Pair<>(0f, 1000f));
+    private static final HeightContainsRangePredicate HEIGHT_PREDICATE = new HeightContainsRangePredicate(
+            new Pair<>(0f, 500f));
     private static final NoteContainsSubstringPredicate NOTE_PREDICATE = new NoteContainsSubstringPredicate(NOTE);
     private static final TagSetContainsAllTagsPredicate TAGS_PREDICATE = new TagSetContainsAllTagsPredicate(
             new HashSet<Tag>(Arrays.asList(new Tag(TAG))));
@@ -63,12 +64,11 @@ public class FindCommandParserTest {
             "");
     private static final EmailContainsSubstringPredicate EMAIL_PREDICATE_EMPTY = new EmailContainsSubstringPredicate(
             "");
-    private static final AddressContainsSubstringPredicate ADDRESS_PREDICATE_EMPTY =
-            new AddressContainsSubstringPredicate("");
-    private static final WeightMapContainsWeightRangePredicate WEIGHT_PREDICATE_EMPTY =
-            new WeightMapContainsWeightRangePredicate(new Pair<>(0f, Float.MAX_VALUE));
-    private static final HeightContainsRangePredicate HEIGHT_PREDICATE_EMPTY =
-            new HeightContainsRangePredicate(new Pair<>(0f, Float.MAX_VALUE));
+    private static final AddressContainsSubstringPredicate ADDRESS_PREDICATE_EMPTY = new AddressContainsSubstringPredicate(
+            "");
+    private static final AlwaysTruePredicate WEIGHT_PREDICATE_EMPTY = new AlwaysTruePredicate();
+    private static final HeightContainsRangePredicate HEIGHT_PREDICATE_EMPTY = new HeightContainsRangePredicate(
+            new Pair<>(0f, Float.MAX_VALUE));
     private static final NoteContainsSubstringPredicate NOTE_PREDICATE_EMPTY = new NoteContainsSubstringPredicate(
             "");
     private static final TagSetContainsAllTagsPredicate TAGS_PREDICATE_EMPTY = new TagSetContainsAllTagsPredicate(
@@ -86,7 +86,8 @@ public class FindCommandParserTest {
     public void parse_nameFieldPresent_returnsFindCommand() {
         FindCommand expectedCommand = new FindCommand(new CombinedPredicates(
                 NAME_PREDICATE, PHONE_PREDICATE_EMPTY, EMAIL_PREDICATE_EMPTY, ADDRESS_PREDICATE_EMPTY,
-                WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE_EMPTY, TAGS_PREDICATE_EMPTY));
+                WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE_EMPTY,
+                TAGS_PREDICATE_EMPTY));
 
         assertParseSuccess(parser, String.format(" %s%s", PREFIX_NAME, NAME), expectedCommand);
 
@@ -98,7 +99,8 @@ public class FindCommandParserTest {
     public void parse_phoneFieldPresent_returnsFindCommand() {
         FindCommand expectedCommand = new FindCommand(new CombinedPredicates(
                 NAME_PREDICATE_EMPTY, PHONE_PREDICATE, EMAIL_PREDICATE_EMPTY, ADDRESS_PREDICATE_EMPTY,
-                WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE_EMPTY, TAGS_PREDICATE_EMPTY));
+                WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE_EMPTY,
+                TAGS_PREDICATE_EMPTY));
 
         assertParseSuccess(parser, String.format(" %s%s", PREFIX_PHONE, PHONE), expectedCommand);
 
@@ -110,7 +112,8 @@ public class FindCommandParserTest {
     public void parse_emailFieldPresent_returnsFindCommand() {
         FindCommand expectedCommand = new FindCommand(new CombinedPredicates(
                 NAME_PREDICATE_EMPTY, PHONE_PREDICATE_EMPTY, EMAIL_PREDICATE, ADDRESS_PREDICATE_EMPTY,
-                WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE_EMPTY, TAGS_PREDICATE_EMPTY));
+                WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE_EMPTY,
+                TAGS_PREDICATE_EMPTY));
 
         assertParseSuccess(parser, String.format(" %s%s", PREFIX_EMAIL, EMAIL), expectedCommand);
 
@@ -122,7 +125,8 @@ public class FindCommandParserTest {
     public void parse_addressFieldPresent_returnsFindCommand() {
         FindCommand expectedCommand = new FindCommand(new CombinedPredicates(
                 NAME_PREDICATE_EMPTY, PHONE_PREDICATE_EMPTY, EMAIL_PREDICATE_EMPTY, ADDRESS_PREDICATE,
-                WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE_EMPTY, TAGS_PREDICATE_EMPTY));
+                WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE_EMPTY,
+                TAGS_PREDICATE_EMPTY));
 
         assertParseSuccess(parser, String.format(" %s%s", PREFIX_ADDRESS, ADDRESS), expectedCommand);
 
@@ -133,7 +137,8 @@ public class FindCommandParserTest {
     @Test
     public void parse_noteFieldPresent_returnsFindCommand() {
         FindCommand expectedCommand = new FindCommand(new CombinedPredicates(
-                NAME_PREDICATE_EMPTY, PHONE_PREDICATE_EMPTY, EMAIL_PREDICATE_EMPTY, ADDRESS_PREDICATE_EMPTY,
+                NAME_PREDICATE_EMPTY, PHONE_PREDICATE_EMPTY, EMAIL_PREDICATE_EMPTY,
+                ADDRESS_PREDICATE_EMPTY,
                 WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE, TAGS_PREDICATE_EMPTY));
 
         assertParseSuccess(parser, String.format(" %s%s", PREFIX_NOTE, NOTE), expectedCommand);
@@ -145,7 +150,8 @@ public class FindCommandParserTest {
     @Test
     public void parse_weightFieldPresent_returnsFindCommand() {
         FindCommand expectedCommand = new FindCommand(new CombinedPredicates(
-                NAME_PREDICATE_EMPTY, PHONE_PREDICATE_EMPTY, EMAIL_PREDICATE_EMPTY, ADDRESS_PREDICATE_EMPTY,
+                NAME_PREDICATE_EMPTY, PHONE_PREDICATE_EMPTY, EMAIL_PREDICATE_EMPTY,
+                ADDRESS_PREDICATE_EMPTY,
                 WEIGHT_PREDICATE, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE_EMPTY, TAGS_PREDICATE_EMPTY));
 
         assertParseSuccess(parser, String.format(" %s%s", PREFIX_WEIGHT, WEIGHT_RANGE), expectedCommand);
@@ -157,7 +163,8 @@ public class FindCommandParserTest {
     @Test
     public void parse_heightFieldPresent_returnsFindCommand() {
         FindCommand expectedCommand = new FindCommand(new CombinedPredicates(
-                NAME_PREDICATE_EMPTY, PHONE_PREDICATE_EMPTY, EMAIL_PREDICATE_EMPTY, ADDRESS_PREDICATE_EMPTY,
+                NAME_PREDICATE_EMPTY, PHONE_PREDICATE_EMPTY, EMAIL_PREDICATE_EMPTY,
+                ADDRESS_PREDICATE_EMPTY,
                 WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE, NOTE_PREDICATE_EMPTY, TAGS_PREDICATE_EMPTY));
 
         assertParseSuccess(parser, String.format(" %s%s", PREFIX_HEIGHT, HEIGHT_RANGE), expectedCommand);
@@ -183,7 +190,8 @@ public class FindCommandParserTest {
     public void parse_multipleFieldsPresent_returnsFindCommand() {
         FindCommand expectedCommand = new FindCommand(new CombinedPredicates(
                 NAME_PREDICATE, PHONE_PREDICATE, EMAIL_PREDICATE_EMPTY, ADDRESS_PREDICATE_EMPTY,
-                WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE_EMPTY, TAGS_PREDICATE_EMPTY));
+                WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE_EMPTY,
+                TAGS_PREDICATE_EMPTY));
 
         assertParseSuccess(parser, String.format(" %s%s %s%s", PREFIX_NAME, NAME, PREFIX_PHONE, PHONE),
                 expectedCommand);
@@ -194,13 +202,15 @@ public class FindCommandParserTest {
     }
 
     /**
-     * Tests for valid searching even when no prefix is specified for searching via a certain attribute.
+     * Tests for valid searching even when no prefix is specified for searching via
+     * a certain attribute.
      * This would default to searching via the {@code Name} attribute.
      */
     @Test
     public void parse_noAttributeSpecified_returnsFindCommand() {
         CombinedPredicates expectedPredicates = new CombinedPredicates(NAME_PREDICATE, PHONE_PREDICATE_EMPTY,
-                EMAIL_PREDICATE_EMPTY, ADDRESS_PREDICATE_EMPTY, WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY,
+                EMAIL_PREDICATE_EMPTY, ADDRESS_PREDICATE_EMPTY, WEIGHT_PREDICATE_EMPTY,
+                HEIGHT_PREDICATE_EMPTY,
                 NOTE_PREDICATE_EMPTY, TAGS_PREDICATE_EMPTY);
         FindCommand expectedCommand = new FindCommand(expectedPredicates);
 
@@ -221,7 +231,8 @@ public class FindCommandParserTest {
     public void parse_preambleWithEmailSpecified_returnsFindCommand() {
         FindCommand expectedCommand = new FindCommand(new CombinedPredicates(
                 NAME_PREDICATE, PHONE_PREDICATE_EMPTY, EMAIL_PREDICATE, ADDRESS_PREDICATE_EMPTY,
-                WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE_EMPTY, TAGS_PREDICATE_EMPTY));
+                WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE_EMPTY,
+                TAGS_PREDICATE_EMPTY));
 
         assertParseSuccess(parser, String.format("%s %s%s", NAME, PREFIX_EMAIL, EMAIL),
                 expectedCommand);
@@ -231,7 +242,8 @@ public class FindCommandParserTest {
     public void parse_preambleWithAddressSpecified_returnsFindCommand() {
         FindCommand expectedCommand = new FindCommand(new CombinedPredicates(
                 NAME_PREDICATE, PHONE_PREDICATE_EMPTY, EMAIL_PREDICATE_EMPTY, ADDRESS_PREDICATE,
-                WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE_EMPTY, TAGS_PREDICATE_EMPTY));
+                WEIGHT_PREDICATE_EMPTY, HEIGHT_PREDICATE_EMPTY, NOTE_PREDICATE_EMPTY,
+                TAGS_PREDICATE_EMPTY));
 
         assertParseSuccess(parser, String.format("%s %s%s", NAME, PREFIX_ADDRESS, ADDRESS),
                 expectedCommand);


### PR DESCRIPTION
Resolves #222 

Issue was that clients without any weights would always return false in the `isMatch()` method, which meant that it would not be matched for any searches in the find command.

Also created a test case to check for this bug (Add new client --> search for new client)