### PR TITLE
Bugfix: Exercise related bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -213,19 +213,29 @@ Alternatively, you can use any one of the supported prefixes to quickly add a pr
 
 Format: `fitadd INDEX [/arms] [/legs] [/chest] [/back] [/shoulders] [/abs] [/all]`
 
+| Prefix     | Exercises                                                                                                                                             |
+|------------|-------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `/arms`      | `bicep curls` - sets: 3, reps: 10, break: 60<br/>`tricep dips` - sets: 3, reps: 12, break: 60<br/>`push-ups` - sets: 3, reps: 15, break: 90           |
+| `/legs`      | `squats` - sets: 4, reps: 15, break: 90<br/>`lunges` - sets: 3, reps: 12, break: 60<br/>`calf raises` - sets: 3, reps: 20, break: 60                  |
+| `/chest`     | `bench press` - sets: 4, reps: 8, break: 120<br/>`push-ups` - sets: 3, reps: 15, break: 90<br/>`chest fly` - sets: 3, reps: 10, break: 90             |
+| `/back`      | `pull-ups` - sets: 3, reps: 8, break: 120<br/>`bent-over rows` - sets: 3, reps: 10, break: 90<br/>`lat pull-downs` - sets: 3, reps: 12, break: 60     |
+| `/shoulders` | `shoulder press` - sets: 3, reps: 10, break: 90<br/>`lateral raises` - sets: 3, reps: 12, break: 60<br/>`front raises` - sets: 3, reps: 10, break: 60 |
+| `/abs`       | `crunches` - sets: 3, reps: 20, break: 60<br/>`plank` - sets: 3, reps: 60, break: 90<br/>`russian twists` - sets: 3, reps: 15, break: 60              |
+| `/all`       | A combination of all exercises from the other prefixes                                                                                                |
+
 <div markdown="block" class="alert alert-warning">:warning: **Warning**
 
-You must either specify a specific an exercise name or use one or more of the default supported prefixes, but not both together.
+You must either specify an exercise name or use one or more of the default supported prefixes, but not both together.
 </div>
 
 <div markdown="block" class="alert alert-warning">:warning: **Warning**
 
-If you are adding an exercise that already exists for the client, the old exercise will be overwritten with the newly supplied field value(s), or a default set of values (sets: 1, reps: 1, break: 0) for the value(s) that are not supplied.
+If you are adding an exercise that already exists for the client, the exercise will be overwritten with the newly supplied field value(s), or a default set of values (sets: 1, reps: 1, break: 0) for the value(s) that are not supplied.
 </div>
 
 <div markdown="block" class="alert alert-warning">:warning: **Warning**
 
-Using the default supported prefixes will overwrite exercises with a default set of values, if any of those default exercises already exists for the client.
+Using the default supported prefixes will overwrite exercises with the pre-defined set of values, if any of those pre-defined default exercises already exists for the client.
 </div>
 
 Examples:

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -257,8 +257,6 @@ Alternatively, you can use the `/all` prefix to delete all exercises from the sp
 
 Format: `fitdelete INDEX /all`
 
-* Specifying the `/all` prefix more than once will simply be treated as if it was only supplied once.
- 
 <div markdown="block" class="alert alert-warning">:warning: **Warning**
 
 You must either specify a specific exercise name or the `/all` prefix, but not both together.

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -208,11 +208,11 @@ If `/edit` is supplied instead of a note, (e.g. `note 1 /edit`), the contents of
 Format: `fitadd INDEX n/EXERCISE_NAME [s/SETS] [r/REPS] [b/BREAK_BETWEEN_SETS_IN_SECONDS]`
 
 * Adds the specified exercise to the client specified by `INDEX`. The index refers to the index number shown in the displayed client list. The index **must be a positive integer** 1, 2, 3, …​
-* Exercise names are **case-insensitive**.
-* Overwrites the specified exercise if it already exists for the client.
-* An exercise is deemed to already exist if the case-insensitive user-supplied exercise name completely matches an existing exercise name for the client.
+* `EXERCISE_NAME` is **case-insensitive**.
+* Overwrites the specified exercise and its values if the exercise already exists for the client.
+* An exercise is deemed to already exist if the case-insensitive user-supplied exercise name completely matches an existing exercise name of the client.
 
-Alternatively, you can use any one of the supported prefixes to quickly add a predefined set of related exercises to the specified client.
+Alternatively, you can use **one or more** of the supported prefixes to quickly add a predefined set of related exercises to the specified client.
 
 Format: `fitadd INDEX [/arms] [/legs] [/chest] [/back] [/shoulders] [/abs] [/all]`
 
@@ -228,17 +228,17 @@ Format: `fitadd INDEX [/arms] [/legs] [/chest] [/back] [/shoulders] [/abs] [/all
 
 <div markdown="block" class="alert alert-warning">:warning: **Warning**
 
-You must either specify an exercise name or use one or more of the default supported prefixes, but not both together.
+You must either specify an exercise name, or use one or more of the default supported prefixes, but not both together.
 </div>
 
 <div markdown="block" class="alert alert-warning">:warning: **Warning**
 
-If you are adding an exercise that already exists for the client, the exercise will be overwritten with the newly supplied field value(s), or a default set of values (sets: 1, reps: 1, break: 0) for the value(s) that are not supplied.
+If you are adding an exercise that already exists for the client, the exercise will be overwritten with the newly supplied exercise value(s), or a default set of exercise values (ie. sets: 1, reps: 1, break: 0) for the exercise value(s) that are not supplied.
 </div>
 
 <div markdown="block" class="alert alert-warning">:warning: **Warning**
 
-Using the default supported prefixes will overwrite exercises with the pre-defined set of values, if any of those pre-defined default exercises already exists for the client.
+Using the default supported prefixes will overwrite exercises with the predefined set of values, if any of those predefined default exercises already exists for the client.
 </div>
 
 Examples:
@@ -255,7 +255,7 @@ Examples:
 Format: `fitdelete INDEX n/EXERCISE_NAME`
 
 * Deletes the specified exercise from the client specified by `INDEX`. The index refers to the index number shown in the displayed client list. The index **must be a positive integer** 1, 2, 3, …​
-* Exercise names are **case-insensitive**.
+* `EXERCISE_NAME` is **case-insensitive**.
 
 Alternatively, you can use the `/all` prefix to delete all exercises from the specified client.
 
@@ -263,14 +263,13 @@ Format: `fitdelete INDEX /all`
 
 <div markdown="block" class="alert alert-warning">:warning: **Warning**
 
-You must either specify a specific exercise name or the `/all` prefix, but not both together.
+You must either specify a specific an exercise name or the `/all` prefix, but not both together.
 </div>
 
 Examples:
 
 * `fitdelete 1 n/burpees` - Deletes the exercise with name `burpees` from the 1st client.
 * `fitdelete 2 /all` - Deletes all exercise(s) from the 2nd client.
-* `fitdelete 2 /all /all` - Deletes all exercise(s) from the 2nd client.
 <hr>
 
 ### Adding a weight value to a client : `weight`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -203,12 +203,11 @@ If `/edit` is supplied instead of a note, (e.g. `note 1 /edit`), the contents of
 > Executing the command `note 1 /edit` will replace the contents of the command box with `note 1 Wants to gain muscle`.
 <hr>
 
-### Adding or overriding exercise(s) of clients : `fitadd`
+### Adding or overwriting exercise(s) of clients : `fitadd`
 
 Format: `fitadd INDEX n/EXERCISE_NAME [s/SETS] [r/REPS] [b/BREAK_BETWEEN_SETS_IN_SECONDS]`
 
-* Adds the specified exercise(s) to the client specified by `INDEX`. The index refers to the index number shown in the displayed client list. The index **must be a positive integer** 1, 2, 3, …​
-* If an exercise with same name already exists for the client, the old exercise will be overwritten with the newly supplied field values, or a default set of values (sets: 1, reps: 1, break: 0) if not supplied.
+* Adds or overwrites the specified exercise of the client specified by `INDEX`. The index refers to the index number shown in the displayed client list. The index **must be a positive integer** 1, 2, 3, …​
 
 Alternatively, you can use any one of the supported prefixes to quickly add a predefined set of related exercises to the specified client.
 
@@ -216,12 +215,23 @@ Format: `fitadd INDEX [/arms] [/legs] [/chest] [/back] [/shoulders] [/abs] [/all
 
 <div markdown="block" class="alert alert-warning">:warning: **Warning**
 
-You must either specify a specific exercise name or use a number of default supported prefixes, but not both together.
+You must either specify a specific an exercise name or use one or more of the default supported prefixes, but not both together.
+</div>
+
+<div markdown="block" class="alert alert-warning">:warning: **Warning**
+
+If you are adding an exercise that already exists for the client, the old exercise will be overwritten with the newly supplied field value(s), or a default set of values (sets: 1, reps: 1, break: 0) for the value(s) that are not supplied.
+</div>
+
+<div markdown="block" class="alert alert-warning">:warning: **Warning**
+
+Using the default supported prefixes will overwrite exercises with a default set of values, if any of those default exercises already exists for the client.
 </div>
 
 Examples:
 
-* `fitadd 1 n/burpees` - Adds or overwrites the `burpees` exercise of the 1st client with a default set of 1, repetition of 1 and 0 seconds break time between sets.
+* `fitadd 1 n/burpees` - Adds or overwrites the `burpees` exercise of the 1st client with a default set of 1, default repetition of 1 and default 0 seconds break time between sets.
+* `fitadd 1 n/burpees r/5` - Adds or overwrites the `burpees` exercise of the 1st client with a default set of 1, repetitions of 5 and default 0 seconds break time between sets.
 * `fitadd 1 n/burpees s/3 r/5 b/30` - Adds or overwrites the `burpees` exercise of the 1st client with sets of 3, repetitions of 5 and 30 seconds break time between sets.
 * `fitadd 2 /arms` - Adds or overwrites a default set of exercises from the `arms` category to the 2nd client.
 * `fitadd 2 /arms /legs` - Adds or overwrites a default set of exercises from the `arms` and `legs` category to the 2nd client.
@@ -229,10 +239,15 @@ Examples:
 
 ### Deleting exercise(s) of clients : `fitdelete`
 
-Format: `fitdelete INDEX n/EXERCISE_NAME [/all]`
+Format: `fitdelete INDEX n/EXERCISE_NAME`
 
-* Deletes the specified exercises(s) from the client specified by `INDEX`. The index refers to the index number shown in the displayed client list. The index **must be a positive integer** 1, 2, 3, …​
-* Supplying the `/all` prefix deletes all exercise(s) from the specified client.
+* Deletes the specified exercise from the client specified by `INDEX`. The index refers to the index number shown in the displayed client list. The index **must be a positive integer** 1, 2, 3, …​
+
+Alternatively, you can use the `/all` prefix to delete all exercises from the specified client.
+
+Format: `fitdelete INDEX /all`
+
+* Specifying the `/all` prefix more than once will simply be treated as if it was only supplied once.
  
 <div markdown="block" class="alert alert-warning">:warning: **Warning**
 
@@ -243,6 +258,7 @@ Examples:
 
 * `fitdelete 1 n/burpees` - Deletes the exercise with name `burpees` from the 1st client.
 * `fitdelete 2 /all` - Deletes all exercise(s) from the 2nd client.
+* `fitdelete 2 /all /all` - Deletes all exercise(s) from the 2nd client.
 <hr>
 
 ### Adding a weight value to a client : `weight`

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -207,7 +207,10 @@ If `/edit` is supplied instead of a note, (e.g. `note 1 /edit`), the contents of
 
 Format: `fitadd INDEX n/EXERCISE_NAME [s/SETS] [r/REPS] [b/BREAK_BETWEEN_SETS_IN_SECONDS]`
 
-* Adds or overwrites the specified exercise of the client specified by `INDEX`. The index refers to the index number shown in the displayed client list. The index **must be a positive integer** 1, 2, 3, …​
+* Adds the specified exercise to the client specified by `INDEX`. The index refers to the index number shown in the displayed client list. The index **must be a positive integer** 1, 2, 3, …​
+* Exercise names are **case-insensitive**.
+* Overwrites the specified exercise if it already exists for the client.
+* An exercise is deemed to already exist if the case-insensitive user-supplied exercise name completely matches an existing exercise name for the client.
 
 Alternatively, you can use any one of the supported prefixes to quickly add a predefined set of related exercises to the specified client.
 
@@ -252,6 +255,7 @@ Examples:
 Format: `fitdelete INDEX n/EXERCISE_NAME`
 
 * Deletes the specified exercise from the client specified by `INDEX`. The index refers to the index number shown in the displayed client list. The index **must be a positive integer** 1, 2, 3, …​
+* Exercise names are **case-insensitive**.
 
 Alternatively, you can use the `/all` prefix to delete all exercises from the specified client.
 

--- a/src/main/java/seedu/address/commons/util/StringUtil.java
+++ b/src/main/java/seedu/address/commons/util/StringUtil.java
@@ -83,27 +83,4 @@ public class StringUtil {
         return true;
     }
 
-    /**
-     * Capitalizes the first letter in each word in the given string and lower-cases the rest of the letters.
-     *
-     * @return The newly processed string.
-     */
-    public static String capitalizeWords(String str) {
-        if (str == null || str.isEmpty()) {
-            return str;
-        }
-
-        String[] words = str.split("\\s+");
-        StringBuilder result = new StringBuilder();
-
-        for (String word : words) {
-            if (!word.isEmpty()) {
-                result.append(Character.toUpperCase(word.charAt(0)))
-                    .append(word.substring(1).toLowerCase())
-                    .append(" ");
-            }
-        }
-
-        return result.toString().trim();
-    }
 }

--- a/src/main/java/seedu/address/logic/commands/FitAddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FitAddCommand.java
@@ -85,23 +85,6 @@ public class FitAddCommand extends Command {
         Set<Exercise> updatedExercises = new HashSet<>(personToEdit.getExerciseSet().getValue());
 
         for (Exercise exerciseToAdd : this.exercisesToAdd) {
-            if (updatedExercises.contains(exerciseToAdd)) {
-                for (Exercise e : updatedExercises) {
-                    if (e.equals(exerciseToAdd)) {
-                        String name = exerciseToAdd.getName();
-                        Integer sets =
-                            exerciseToAdd.getSets() != Exercise.DEFAULT_SETS ? exerciseToAdd.getSets() : e.getSets();
-                        Integer reps =
-                            exerciseToAdd.getReps() != Exercise.DEFAULT_REPS ? exerciseToAdd.getReps() : e.getReps();
-                        Integer breakBetweenSets = exerciseToAdd.getBreakBetweenSets() != Exercise.DEFAULT_BREAK
-                            ? exerciseToAdd.getBreakBetweenSets() : e.getBreakBetweenSets();
-
-                        exerciseToAdd = new Exercise(name, sets, reps, breakBetweenSets);
-                        break;
-                    }
-                }
-            }
-
             updatedExercises.remove(exerciseToAdd);
             updatedExercises.add(exerciseToAdd);
         }

--- a/src/main/java/seedu/address/logic/messages/FitAddCommandMessages.java
+++ b/src/main/java/seedu/address/logic/messages/FitAddCommandMessages.java
@@ -44,8 +44,12 @@ public class FitAddCommandMessages extends Messages {
     public static final String MESSAGE_EXERCISE_NAME_PARAMETER_AND_DEFAULT_PREFIXES_MISSING =
         String.format("Either exercise name parameter or default exercise prefix(es) must be supplied\n%1$s",
             MESSAGE_USAGE);
-    public static final String MESSAGE_ADD_EXERCISE_CONFLICTING_PREFIXES =
+    public static final String MESSAGE_ADD_EXERCISE_NAME_CONFLICTING_PREFIXES =
         String.format("Exercise name parameter cannot be supplied together with default exercise prefix(es)\n%1$s",
+            MESSAGE_USAGE);
+
+    public static final String MESSAGE_ADD_EXERCISE_VALUES_CONFLICTING_PREFIXES =
+        String.format("Exercise value parameter(s) cannot be supplied together with default exercise prefix(es)\n%1$s",
             MESSAGE_USAGE);
     public static final String MESSAGE_ADD_EXERCISE_SUCCESS = "Successfully added exercise(s) for client";
 }

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -125,7 +125,7 @@ public class ArgumentMultimap {
     public boolean hasArgumentValueForPrefixes(Prefix... prefixes) {
         Prefix[] prefixesWithValues = Stream.of(prefixes).distinct()
             .filter(prefix -> this.argMultimap.containsKey(prefix) && !this.argMultimap.get(prefix).isEmpty()
-                && !this.argMultimap.get(prefix).get(0).isEmpty())
+                && !this.argMultimap.get(prefix).stream().allMatch(String::isEmpty))
             .toArray(Prefix[]::new);
 
         return prefixesWithValues.length > 0;

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -116,6 +116,22 @@ public class ArgumentMultimap {
     }
 
     /**
+     * Checks if the argument multimap contains a non-empty value for any of the specified prefixes.
+     *
+     * @param prefixes the prefixes to check for argument values
+     * @return {@code true} if at least one of the specified prefixes has a non-empty argument value,
+     *      {@code false} otherwise
+     */
+    public boolean hasArgumentValueForPrefixes(Prefix... prefixes) {
+        Prefix[] prefixesWithValues = Stream.of(prefixes).distinct()
+            .filter(prefix -> this.argMultimap.containsKey(prefix) && !this.argMultimap.get(prefix).isEmpty()
+                && !this.argMultimap.get(prefix).get(0).isEmpty())
+            .toArray(Prefix[]::new);
+
+        return prefixesWithValues.length > 0;
+    }
+
+    /**
      * Returns true if the prefix exists as a key in the map.
      */
     public boolean contains(Prefix prefix) {

--- a/src/main/java/seedu/address/logic/parser/FitAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FitAddCommandParser.java
@@ -84,7 +84,8 @@ public class FitAddCommandParser implements Parser<FitAddCommand> {
         }
     }
 
-    private void verifyNoConflictingPrefixes(boolean hasExerciseNamePrefix, boolean hasExerciseValuesPrefix, boolean hasDefaultExercisePrefixes)
+    private void verifyNoConflictingPrefixes(boolean hasExerciseNamePrefix, boolean hasExerciseValuesPrefix,
+                                             boolean hasDefaultExercisePrefixes)
             throws ParseException {
         if (hasExerciseNamePrefix && hasDefaultExercisePrefixes) {
             throw new ParseException(FitAddCommandMessages.MESSAGE_ADD_EXERCISE_NAME_CONFLICTING_PREFIXES);

--- a/src/main/java/seedu/address/logic/parser/FitAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FitAddCommandParser.java
@@ -84,10 +84,14 @@ public class FitAddCommandParser implements Parser<FitAddCommand> {
         }
     }
 
-    private void verifyNoConflictingPrefixes(boolean hasExerciseNamePrefix, boolean hasDefaultExercisePrefixes)
+    private void verifyNoConflictingPrefixes(boolean hasExerciseNamePrefix, boolean hasExerciseValuesPrefix, boolean hasDefaultExercisePrefixes)
             throws ParseException {
         if (hasExerciseNamePrefix && hasDefaultExercisePrefixes) {
-            throw new ParseException(FitAddCommandMessages.MESSAGE_ADD_EXERCISE_CONFLICTING_PREFIXES);
+            throw new ParseException(FitAddCommandMessages.MESSAGE_ADD_EXERCISE_NAME_CONFLICTING_PREFIXES);
+        }
+
+        if (hasDefaultExercisePrefixes && hasExerciseValuesPrefix) {
+            throw new ParseException(FitAddCommandMessages.MESSAGE_ADD_EXERCISE_VALUES_CONFLICTING_PREFIXES);
         }
     }
 
@@ -171,12 +175,14 @@ public class FitAddCommandParser implements Parser<FitAddCommand> {
 
         // Get existence of relevant prefixes
         boolean hasExerciseNamePrefix = argumentMultimap.contains(PREFIX_EXERCISE_NAME);
+        boolean hasExerciseValuesPrefix = argumentMultimap.containsAny(PREFIX_EXERCISE_SETS,
+            PREFIX_EXERCISE_REPS, PREFIX_EXERCISE_BREAK_BETWEEN_SETS);
         boolean hasDefaultExercisePrefixes = argumentMultimap.containsAny(PREFIX_EXERCISE_ARM, PREFIX_EXERCISE_LEG,
             PREFIX_EXERCISE_CHEST, PREFIX_EXERCISE_BACK, PREFIX_EXERCISE_SHOULDER, PREFIX_EXERCISE_ABS,
             PREFIX_EXERCISE_ALL);
 
         verifyNoMissingPrefixes(hasExerciseNamePrefix, hasDefaultExercisePrefixes);
-        verifyNoConflictingPrefixes(hasExerciseNamePrefix, hasDefaultExercisePrefixes);
+        verifyNoConflictingPrefixes(hasExerciseNamePrefix, hasExerciseValuesPrefix, hasDefaultExercisePrefixes);
 
         return new FitAddCommand(index, getExercisesToAdd(argumentMultimap, hasExerciseNamePrefix));
     }

--- a/src/main/java/seedu/address/logic/parser/FitAddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FitAddCommandParser.java
@@ -166,8 +166,8 @@ public class FitAddCommandParser implements Parser<FitAddCommand> {
 
         Index index = parseIndex(argumentMultimap);
 
-        verifyNoDuplicatePrefixes(argumentMultimap);
         verifyNoArgumentValueForPrefixes(argumentMultimap);
+        verifyNoDuplicatePrefixes(argumentMultimap);
 
         // Get existence of relevant prefixes
         boolean hasExerciseNamePrefix = argumentMultimap.contains(PREFIX_EXERCISE_NAME);

--- a/src/main/java/seedu/address/logic/parser/FitDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FitDeleteCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EXERCISE_ALL;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EXERCISE_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FITDELETE_DELETE_ALL;
 
@@ -46,7 +47,7 @@ public class FitDeleteCommandParser implements Parser<FitDeleteCommand> {
     }
 
     private void verifyNoDuplicatePrefixes(ArgumentMultimap argumentMultimap) throws ParseException {
-        argumentMultimap.verifyNoDuplicatePrefixesFor(PREFIX_EXERCISE_NAME);
+        argumentMultimap.verifyNoDuplicatePrefixesFor(PREFIX_EXERCISE_NAME, PREFIX_EXERCISE_ALL);
     }
 
     private void verifyNoConflictingPrefixes(boolean containsPrefixExerciseName,

--- a/src/main/java/seedu/address/logic/parser/FitDeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FitDeleteCommandParser.java
@@ -89,8 +89,8 @@ public class FitDeleteCommandParser implements Parser<FitDeleteCommand> {
 
         Index index = parseIndex(argumentMultimap);
 
-        verifyNoDuplicatePrefixes(argumentMultimap);
         verifyNoArgumentValueForPrefixes(argumentMultimap);
+        verifyNoDuplicatePrefixes(argumentMultimap);
 
         // Get existence of relevant prefixes
         boolean containsPrefixExerciseName = argumentMultimap.contains(PREFIX_EXERCISE_NAME);

--- a/src/main/java/seedu/address/ui/PersonDetailsPanel.java
+++ b/src/main/java/seedu/address/ui/PersonDetailsPanel.java
@@ -34,7 +34,6 @@ import javafx.scene.paint.Color;
 import javafx.scene.shape.Circle;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.util.DateTimeUtil;
-import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.messages.WeightCommandMessages;
 import seedu.address.model.exercise.Exercise;
 import seedu.address.model.person.Person;
@@ -218,7 +217,7 @@ public class PersonDetailsPanel extends UiPart<Region> {
                 final String exerciseAttrValueStyle =
                     "-fx-background-color: #2E2E2E; -fx-padding: 2 5 2 5; -fx-text-fill: white; -fx-font-size: 12px;";
 
-                Label exerciseName = new Label(StringUtil.capitalizeWords(exercise.getName()));
+                Label exerciseName = new Label(exercise.getName());
 
                 exerciseName.setWrapText(true);
                 exerciseName.setUnderline(true);

--- a/src/test/java/seedu/address/commons/util/StringUtilTest.java
+++ b/src/test/java/seedu/address/commons/util/StringUtilTest.java
@@ -1,8 +1,6 @@
 package seedu.address.commons.util;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
@@ -165,32 +163,4 @@ public class StringUtilTest {
         assertTrue(StringUtil.isInteger(Integer.toString(Integer.MAX_VALUE)));
         assertTrue(StringUtil.isInteger(Integer.toString(Integer.MIN_VALUE)));
     }
-
-    //---------------- Tests for capitalizeWords --------------------------------------
-
-    @Test
-    public void capitalizeWords() {
-
-        // EP: null, should return null
-        assertNull(StringUtil.capitalizeWords(null));
-
-        // EP: empty string, should return empty string
-        assertEquals("", StringUtil.capitalizeWords(""));
-        assertEquals("", StringUtil.capitalizeWords("   "));
-
-        // EP: single word, should capitalize the first letter
-        assertEquals("Hello", StringUtil.capitalizeWords("hello"));
-        assertEquals("Hello", StringUtil.capitalizeWords("HELLO"));
-        assertEquals("Hello", StringUtil.capitalizeWords("heLLo"));
-
-        // EP: multiple words, should capitalize the first letter of each word
-        assertEquals("Hello World", StringUtil.capitalizeWords("hello world"));
-        assertEquals("Hello World", StringUtil.capitalizeWords("HELLO WORLD"));
-        assertEquals("Hello World", StringUtil.capitalizeWords("heLLo wORLd"));
-
-        // EP: words with extra spaces, should capitalize the first letter of each word
-        assertEquals("Hello World", StringUtil.capitalizeWords("  hello  world  "));
-        assertEquals("Hello World", StringUtil.capitalizeWords("hello   world"));
-    }
-
 }


### PR DESCRIPTION
Resolves #292, #280

This resolves the bug where default supported prefixes that are immediately followed by random characters are regarded as valid. (ie. `fitadd 1 /armsrandom` and `fitdelete 1 /allzz`)
This resolves the problem where extraneous inputs are regarded as valid. (ie. `fitadd 1 /arms s/ r/ b/ /aliens` and `fitdelete 1 /all /jsCappin`)

**It is resolved as follows**:
Firstly, the trimmed preamble (text between the command and the first prefix (or end of string)) is checked to ensure that it does not contain any spaces. This is used to ensure that the index is valid as well as to ensure that any text that comes after the index must be a valid prefix.
Secondly, a check is performed to ensure that all argument values corresponding to the default supported prefixes are empty (ie. only prefix is supplied).
Then, a check is performed to ensure that default supported prefixes are not duplicated.

<hr/>

Resolves #274 

This resolves the bug where not supplying exercise values (ie. `sets`, `reps`, `break`) for an existing exercise results in FitBook keeping the existing values as it is and not over-riding with the default exercise values.

Previously, when the user did not supply any of the exercise value(s) a default value was used. However, prior to overwriting the existing exercise, a check was performed against the new exercise values to determine if the user had supplied any of those values. If the user did supply them it would be used to overwrite, else the existing value will be kept. However, this check was performed by checking against the default exercise values.

An even more serious bug was discovered in the resolution process. That is when a user tries to modify any of the existing exercise values to the default value, it will be rejected regardless of what the existing exercise values were. This is because the check will interpret the command as if the user did not supply those exercise values.

**It is resolved as follows**:
If the exercise to be added already exists, any of exercise value(s) that are not supplied will be replaced with the default value (ie `sets`: 1, `reps`:1, `break`: 0). The previous check is removed.

**Known limitation**: Even if users wish to simply modify a single exercise value (ie. `reps`) but keep the rest of the exercise values the same (ie. `sets`, and `break`) they will now have to manually supply each exercise value and cannot just specify the desired exercise value.

<hr/>

Resolves #273 

This resolves the bug where there is a lack of clarity in the user guide. The `fitdelete` command has 2 variants in the format but it was combined into one.

**It is resolved as follows**:
Both variants are explicitly stated in the user guide.

<hr/>

Resolves #271

This resolves the bug where the user guide does not mention the set of default exercises associated with each default supported prefix.

**It is resolved as follows**:
A table has been added detailing which default exercises (along with their values) are associated with which default supported prefix.

<hr/>

Resolves #268 

This resolves the bug where prettifying the exercise name for display in the exercises tab causes certain distinct exercise names (those that only differ in the number of non-trailing consecutive spaces) to be displayed as identical.

**It is resolved as follows**:
The prettifying method is removed. Exercise names are displayed as is.

<hr/>